### PR TITLE
Allow comments in template

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This `.env.template` means you expect all the variables FOO, BAR, FOOBAR and FOO
 - `boolean` means your variable must be either `'true'` or `'false'` 
 - `string` means your variable must be a valid string. In practice, *any value will pass this test*, because .env variables are always strings.
 
+💡*You can put comments in your env template by using `#`. Great for annotations or sharing default values!*
+
 ### Usage
 
 To run the test, simply import the main function, and pass it your `.env.template` file path. It returns a Promise that will resolve to a `ValidatorResult`. 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -18,11 +18,14 @@ export default (location: string, options: {
       }),
     })
 
-    readInterface.on('line', (line) => {
-      if (!line || line === '') return
+    readInterface.on('line', (line = '') => {
+      const lineWithoutComments = line.replace(/\#(.*)/g, '')
+      if (lineWithoutComments === '') return
 
-      const name = line.split('=')[0]
-      const expectedType = line.split('=')[1].toUpperCase()
+      const name = lineWithoutComments.split('=')[0].trim()
+      const expectedType = lineWithoutComments.split('=')[1]
+        .toUpperCase()
+        .trim()
       const actualValue = process.env[name]
 
       if (!Object.values(VariableType).includes(expectedType as any)) {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -19,13 +19,12 @@ export default (location: string, options: {
     })
 
     readInterface.on('line', (line = '') => {
-      const lineWithoutComments = line.replace(/\#(.*)/g, '')
+      const lineWithoutComments = line.replace(/\#(.*)/g, '').trim()
       if (lineWithoutComments === '') return
 
       const name = lineWithoutComments.split('=')[0].trim()
       const expectedType = lineWithoutComments.split('=')[1]
         .toUpperCase()
-        .trim()
       const actualValue = process.env[name]
 
       if (!Object.values(VariableType).includes(expectedType as any)) {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -23,10 +23,10 @@ export default (location: string, options: {
       if (lineWithoutComments === '') return
 
       const name = lineWithoutComments.split('=')[0].trim()
-      const expectedType = line.split('=')[1]
+      const expectedType = lineWithoutComments.split('=')[1]
         .toUpperCase()
         .replace('?', '')
-      const optional = (line.substr(-1) === '?')
+      const optional = (lineWithoutComments.substr(-1) === '?')
       const actualValue = process.env[name]
 
       if (!Object.values(VariableType).includes(expectedType as any)) {


### PR DESCRIPTION
- Ignore everything after a `#` character.
- Trim values so that a space at the end of a line doesn't kill the validator.

Closes #5 